### PR TITLE
[semver:minor] Change retry build command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.4.0] - 2021-01-11
+
+### Changed
+
+- Change how to handle retry-builds.
+  - Before, it used `when: on_fail` and this worked in CircleCI land, but CircleCI labels any failure of a job a failure overall
+    even with an `on_fail`. So here we use a bash `||` to trigger the rebuild
+
 ## [0.3.0] - 2021-01-10
 
 ### Changed

--- a/src/commands/buildinstall.yml
+++ b/src/commands/buildinstall.yml
@@ -11,12 +11,4 @@ steps:
       name: "Build and install"
       command: |
         cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-<< parameters.repo >>
-        make -j"$(nproc)" install |& tee /logfiles/make.log
-        #MEDIUM# make -j4 install |& tee /logfiles/make.log
-  - run:
-      name: "Retry build and install after failure"
-      command: |
-        cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-<< parameters.repo >>
-        make -j"$(nproc)" install |& tee /logfiles/make-retry.log
-        #MEDIUM# make -j4 install |& tee /logfiles/make-retry.log
-      when: on_fail
+        make -j"$(nproc)" install |& tee /logfiles/make.log || make -j4 install |& tee /logfiles/make-retry.log


### PR DESCRIPTION
Before, it used `when: on_fail` and this worked in CircleCI land, but CircleCI labels any failure of a job a failure overall even with an `on_fail`. So here we use a bash `||` to trigger the rebuild