### PR TITLE
Use machine executor for Docker builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Move to use `machine` executor for CircleCI Docker builds
+
 ### Removed
 
 ## [1.13.1] - 2022-10-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Move to use `machine` executor for CircleCI Docker builds
-
 ### Removed
+
+## [1.14.0] - 2022-10-13
+
+### Changed
+
+- Move to use `machine` executor for CircleCI Docker builds
 
 ## [1.13.1] - 2022-10-13
 

--- a/src/executors/docker.yml
+++ b/src/executors/docker.yml
@@ -7,10 +7,7 @@ parameters:
     default: large
     type: string
 
-docker:
-  - image: cimg/base:2022.06
-    auth:
-      username: $DOCKERHUB_USER
-      password: $DOCKERHUB_AUTH_TOKEN
+machine:
+  - image: ubuntu-2204:2022.04.2
 
 resource_class: << parameters.resource_class >>

--- a/src/executors/docker.yml
+++ b/src/executors/docker.yml
@@ -8,6 +8,6 @@ parameters:
     type: string
 
 machine:
-  - image: ubuntu-2204:2022.04.2
+  image: ubuntu-2204:2022.04.2
 
 resource_class: << parameters.resource_class >>

--- a/src/jobs/publish-docker.yml
+++ b/src/jobs/publish-docker.yml
@@ -70,8 +70,10 @@ executor:
 
 steps:
   - checkout
-  - setup_remote_docker:
-      docker_layer_caching: true
+  - run:
+      name: Login to Docker Hub
+      command: |
+        echo $DOCKERHUB_AUTH_TOKEN | docker login --username $DOCKERHUB_USER --password-stdin
   - run:
       name: Build << parameters.compiler_name >> Docker Image
       command: |
@@ -89,10 +91,6 @@ steps:
   - when:
       condition: << parameters.push_to_dockerhub >>
       steps:
-        - run:
-            name: Login to Docker Hub
-            command: |
-              echo $DOCKERHUB_AUTH_TOKEN | docker login --username $DOCKERHUB_USER --password-stdin
         - run:
             name: Push << parameters.compiler_name >> Docker Image to Docker Hub
             command: |


### PR DESCRIPTION
This PR moves to use the `machine` executor for Docker builds