### PR TITLE
Add bcs_version to docker build job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.16.0] - 2022-10-18
+
+### Added
+
+- Add `bcs_version` as a build arg for docker builds
+
 ## [1.15.1] - 2022-10-18
 
 ### Fixed

--- a/src/jobs/publish-docker.yml
+++ b/src/jobs/publish-docker.yml
@@ -63,6 +63,10 @@ parameters:
     type: string
     default: v7.5.0
     description: "Baselibs version to use"
+  bcs_version:
+    type: string
+    default: ""
+    description: "Boundary conditions version to use"
 
 executor:
   name: docker
@@ -86,6 +90,7 @@ steps:
           --build-arg mpiversion=<< parameters.mpi_version >> \
           --build-arg compilername=<< parameters.compiler_name >> \
           --build-arg compilerversion=<< parameters.compiler_version >> \
+          --build-arg bcsversion=<< parameters.bcs_version >> \
           --build-arg << parameters.tag_build_arg_name >>=$CIRCLE_TAG \
           -t << parameters.container_name >>:${VERSION}-<< parameters.compiler_name >> -f ./.docker/Dockerfile .
   - when:


### PR DESCRIPTION
We need to be able to pass in the BCs version for GEOSgcm builds.