### PR TITLE
Add post and coupled_diagnostics to workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.16.1] - 2022-10-20
+
+### Fixed
+
+- Add `coupled_diagnostics` and `post` to the persisted workspace
+
 ## [1.16.0] - 2022-10-18
 
 ### Added

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -170,6 +170,8 @@ steps:
               - install-<< parameters.repo >>/bin
               - install-<< parameters.repo >>/lib
               - install-<< parameters.repo >>/etc
+              - install-<< parameters.repo >>/post
+              - install-<< parameters.repo >>/coupled_diagnostics
   - compress_artifacts
   - store_artifacts:
       path: /logfiles


### PR DESCRIPTION
For coupled runs, we need to persist the `install/coupled_diagnostics` directory. 

Adding on `post` since I see these (not important) lines:
```
/bin/cp: cannot stat '/root/project/workspace/install-GEOSgcm/post/plot.rc': No such file or directory
/bin/cp: cannot stat '/root/project/workspace/install-GEOSgcm/post/post.rc': No such file or directory
```