### PR TITLE
Add change_layout boolean to makeoneday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.17.0] - 2022-10-20
+
+### Added
+
+- Added `change_layout` boolean to makeoneday command. Needed because the coupled run does not like the layout change.
+
 ## [1.16.1] - 2022-10-20
 
 ### Fixed

--- a/src/commands/run_makeoneday.yml
+++ b/src/commands/run_makeoneday.yml
@@ -19,19 +19,19 @@ parameters:
     default: true
 
 steps:
-  when:
-    condition: << parameters.change_layout >>
-    steps:
-      - run:
-          name: "Run makeoneday, change layout to 1x6"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.workspace_root >>/<< parameters.gcm_experiment_name >>
-            /TinyBCs-GitV10/scripts/makeoneday.bash 1hr nxy 1 6 noext
-  unless:
-    condition: << parameters.change_layout >>
-    steps:
-      - run:
-          name: "Run makeoneday"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.workspace_root >>/<< parameters.gcm_experiment_name >>
-            /TinyBCs-GitV10/scripts/makeoneday.bash 1hr noext
+  - when:
+      condition: << parameters.change_layout >>
+      steps:
+        - run:
+            name: "Run makeoneday, change layout to 1x6"
+            command: |
+              cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.workspace_root >>/<< parameters.gcm_experiment_name >>
+              /TinyBCs-GitV10/scripts/makeoneday.bash 1hr nxy 1 6 noext
+  - unless:
+      condition: << parameters.change_layout >>
+      steps:
+        - run:
+            name: "Run makeoneday"
+            command: |
+              cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.workspace_root >>/<< parameters.gcm_experiment_name >>
+              /TinyBCs-GitV10/scripts/makeoneday.bash 1hr noext

--- a/src/commands/run_makeoneday.yml
+++ b/src/commands/run_makeoneday.yml
@@ -13,10 +13,25 @@ parameters:
     description: "Name of experiment"
     type: string
     default: test-gcm
+  change_layout:
+    description: "Change layout to 1x6 (true for amip, false for coupled)"
+    type: boolean
+    default: true
 
 steps:
-  - run:
-      name: "Run makeoneday"
-      command: |
-        cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.workspace_root >>/<< parameters.gcm_experiment_name >>
-        /TinyBCs-GitV10/scripts/makeoneday.bash 1hr nxy 1 6 noext
+  when:
+    condition: << parameters.change_layout >>
+    steps:
+      - run:
+          name: "Run makeoneday, change layout to 1x6"
+          command: |
+            cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.workspace_root >>/<< parameters.gcm_experiment_name >>
+            /TinyBCs-GitV10/scripts/makeoneday.bash 1hr nxy 1 6 noext
+  unless:
+    condition: << parameters.change_layout >>
+    steps:
+      - run:
+          name: "Run makeoneday"
+          command: |
+            cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.workspace_root >>/<< parameters.gcm_experiment_name >>
+            /TinyBCs-GitV10/scripts/makeoneday.bash 1hr noext


### PR DESCRIPTION
This PR adds a `change_layout` boolean to makeoneday because MOM6 runs do not handle that well. I should fix makeoneday, but for now, this is a good workaround.