### PR TITLE
Move to Baselibs 7.7.0 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.18.0] - 2022-12-16
+
+### Changed
+
+- Moved to use Baselibs 7.7.0 as the default
+
 ## [1.17.0] - 2022-10-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Moved to use Baselibs 7.7.0 as the default
 
-## [1.17.0] - 2022-10-20
+## [1.17.1] - 2022-10-20
 
 ### Fixed
 

--- a/src/executors/README.md
+++ b/src/executors/README.md
@@ -11,7 +11,7 @@ These are named to match the Fortran compiler.
 They have on two optional parameters:
 
 1. `resource_class` which defaults to `large`
-2. `baselibs_version` which defaults to `v7.5.0`
+2. `baselibs_version` which defaults to `v7.7.0`
 3. `bcs_version` which defaults to `v10.23.0`
 
 ## See:

--- a/src/executors/gfortran-bcs.yml
+++ b/src/executors/gfortran-bcs.yml
@@ -8,7 +8,7 @@ parameters:
     type: string
   baselibs_version:
     description: "Version of Baselibs to use"
-    default: v7.5.0
+    default: v7.7.0
     type: string
   bcs_version:
     description: "Version of boundary conditions to use"

--- a/src/executors/gfortran.yml
+++ b/src/executors/gfortran.yml
@@ -8,7 +8,7 @@ parameters:
     type: string
   baselibs_version:
     description: "Version of Baselibs to use"
-    default: v7.5.0
+    default: v7.7.0
     type: string
 
 docker:

--- a/src/executors/ifort-bcs.yml
+++ b/src/executors/ifort-bcs.yml
@@ -8,7 +8,7 @@ parameters:
     type: string
   baselibs_version:
     description: "Version of Baselibs to use"
-    default: v7.5.0
+    default: v7.7.0
     type: string
   bcs_version:
     description: "Version of boundary conditions to use"

--- a/src/executors/ifort.yml
+++ b/src/executors/ifort.yml
@@ -8,7 +8,7 @@ parameters:
     type: string
   baselibs_version:
     description: "Version of Baselibs to use"
-    default: v7.5.0
+    default: v7.7.0
     type: string
 
 docker:

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -18,7 +18,7 @@ parameters:
     enum: ["medium", "large", "xlarge"]
   baselibs_version:
     type: string
-    default: v7.5.0
+    default: v7.7.0
     description: "Baselibs version to use"
   checkout_fixture:
     type: boolean

--- a/src/jobs/publish-docker.yml
+++ b/src/jobs/publish-docker.yml
@@ -61,7 +61,7 @@ parameters:
     description: "MPI Version on image"
   baselibs_version:
     type: string
-    default: v7.5.0
+    default: v7.7.0
     description: "Baselibs version to use"
   bcs_version:
     type: string

--- a/src/jobs/run_fv3.yml
+++ b/src/jobs/run_fv3.yml
@@ -18,7 +18,7 @@ parameters:
     enum: ["medium", "large", "xlarge"]
   baselibs_version:
     type: string
-    default: v7.5.0
+    default: v7.7.0
     description: "Baselibs version to use"
   workspace_root:
     description: "Workspace root"

--- a/src/jobs/run_gcm.yml
+++ b/src/jobs/run_gcm.yml
@@ -18,7 +18,7 @@ parameters:
     enum: ["medium", "large", "xlarge"]
   baselibs_version:
     type: string
-    default: v7.5.0
+    default: v7.7.0
     description: "Baselibs version to use"
   bcs_version:
     type: string

--- a/src/jobs/run_mapl_tutorial.yml
+++ b/src/jobs/run_mapl_tutorial.yml
@@ -18,7 +18,7 @@ parameters:
     enum: ["medium", "large", "xlarge"]
   baselibs_version:
     type: string
-    default: v7.5.0
+    default: v7.7.0
     description: "Baselibs version to use"
   workspace_root:
     description: "Workspace root"


### PR DESCRIPTION
This PR moves the circleci-tools orb to use Baselibs 7.7.0 by default.