### PR TITLE
Update BCs Version to v11.00.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.19.0] - 2023-03-15
+
+### Changed
+
+- Moved to use BCs version v11.0.0 as the default
+
 ## [1.18.0] - 2022-12-16
 
 ### Changed
 
-- Moved to use Baselibs 7.7.0 as the default
+- Moved to use Baselibs v7.7.0 as the default
 
 ## [1.17.1] - 2022-10-20
 

--- a/src/executors/README.md
+++ b/src/executors/README.md
@@ -12,7 +12,7 @@ They have on two optional parameters:
 
 1. `resource_class` which defaults to `large`
 2. `baselibs_version` which defaults to `v7.7.0`
-3. `bcs_version` which defaults to `v10.23.0`
+3. `bcs_version` which defaults to `v11.00.0`
 
 ## See:
  - [Orb Author Intro](https://circleci.com/docs/2.0/orb-author-intro/#section=configuration)

--- a/src/executors/gfortran-bcs.yml
+++ b/src/executors/gfortran-bcs.yml
@@ -12,7 +12,7 @@ parameters:
     type: string
   bcs_version:
     description: "Version of boundary conditions to use"
-    default: v10.23.0
+    default: v11.00.0
     type: string
 
 docker:

--- a/src/executors/ifort-bcs.yml
+++ b/src/executors/ifort-bcs.yml
@@ -12,7 +12,7 @@ parameters:
     type: string
   bcs_version:
     description: "Version of boundary conditions to use"
-    default: v10.23.0
+    default: v11.00.0
     type: string
 
 docker:

--- a/src/jobs/run_gcm.yml
+++ b/src/jobs/run_gcm.yml
@@ -22,7 +22,7 @@ parameters:
     description: "Baselibs version to use"
   bcs_version:
     type: string
-    default: v10.23.0
+    default: v11.00.0
     description: "Boundary condition version to use"
   workspace_root:
     description: "Workspace root"


### PR DESCRIPTION
This PR updates the BCs to use v11.00.0 by default.