### PR TITLE
Update to Baselibs v7.13.0 and BCs v11.1.0 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.21.0] - 2023-06-22
+
+### Changed
+
+- Update to use Baselibs v7.13.0 and BCs v11.1.0 by default
+
 ## [1.20.0] - 2023-05-30
 
 ### Added

--- a/src/executors/README.md
+++ b/src/executors/README.md
@@ -11,8 +11,8 @@ These are named to match the Fortran compiler.
 They have on two optional parameters:
 
 1. `resource_class` which defaults to `large`
-2. `baselibs_version` which defaults to `v7.7.0`
-3. `bcs_version` which defaults to `v11.00.0`
+2. `baselibs_version` which defaults to `v7.13.0`
+3. `bcs_version` which defaults to `v11.1.0`
 
 ## See:
  - [Orb Author Intro](https://circleci.com/docs/2.0/orb-author-intro/#section=configuration)

--- a/src/executors/gfortran-bcs.yml
+++ b/src/executors/gfortran-bcs.yml
@@ -8,11 +8,11 @@ parameters:
     type: string
   baselibs_version:
     description: "Version of Baselibs to use"
-    default: v7.7.0
+    default: v7.13.0
     type: string
   bcs_version:
     description: "Version of boundary conditions to use"
-    default: v11.00.0
+    default: v11.1.0
     type: string
 
 docker:

--- a/src/executors/gfortran.yml
+++ b/src/executors/gfortran.yml
@@ -8,7 +8,7 @@ parameters:
     type: string
   baselibs_version:
     description: "Version of Baselibs to use"
-    default: v7.7.0
+    default: v7.13.0
     type: string
 
 docker:

--- a/src/executors/ifort-bcs.yml
+++ b/src/executors/ifort-bcs.yml
@@ -8,11 +8,11 @@ parameters:
     type: string
   baselibs_version:
     description: "Version of Baselibs to use"
-    default: v7.7.0
+    default: v7.13.0
     type: string
   bcs_version:
     description: "Version of boundary conditions to use"
-    default: v11.00.0
+    default: v11.1.0
     type: string
 
 docker:

--- a/src/executors/ifort.yml
+++ b/src/executors/ifort.yml
@@ -8,7 +8,7 @@ parameters:
     type: string
   baselibs_version:
     description: "Version of Baselibs to use"
-    default: v7.7.0
+    default: v7.13.0
     type: string
 
 docker:

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -18,7 +18,7 @@ parameters:
     enum: ["medium", "large", "xlarge"]
   baselibs_version:
     type: string
-    default: v7.7.0
+    default: v7.13.0
     description: "Baselibs version to use"
   checkout_fixture:
     type: boolean

--- a/src/jobs/publish-docker.yml
+++ b/src/jobs/publish-docker.yml
@@ -61,7 +61,7 @@ parameters:
     description: "MPI Version on image"
   baselibs_version:
     type: string
-    default: v7.7.0
+    default: v7.13.0
     description: "Baselibs version to use"
   bcs_version:
     type: string

--- a/src/jobs/run_fv3.yml
+++ b/src/jobs/run_fv3.yml
@@ -18,7 +18,7 @@ parameters:
     enum: ["medium", "large", "xlarge"]
   baselibs_version:
     type: string
-    default: v7.7.0
+    default: v7.13.0
     description: "Baselibs version to use"
   workspace_root:
     description: "Workspace root"

--- a/src/jobs/run_gcm.yml
+++ b/src/jobs/run_gcm.yml
@@ -18,11 +18,11 @@ parameters:
     enum: ["medium", "large", "xlarge"]
   baselibs_version:
     type: string
-    default: v7.7.0
+    default: v7.13.0
     description: "Baselibs version to use"
   bcs_version:
     type: string
-    default: v11.00.0
+    default: v11.1.0
     description: "Boundary condition version to use"
   workspace_root:
     description: "Workspace root"

--- a/src/jobs/run_mapl_tutorial.yml
+++ b/src/jobs/run_mapl_tutorial.yml
@@ -18,7 +18,7 @@ parameters:
     enum: ["medium", "large", "xlarge"]
   baselibs_version:
     type: string
-    default: v7.7.0
+    default: v7.13.0
     description: "Baselibs version to use"
   workspace_root:
     description: "Workspace root"


### PR DESCRIPTION
As the title says, update to use Baselibs v7.13.0 and BCs v11.1.0 by default.