### PR TITLE
Update default BCs to v11.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.25.0] - 2023-10-31
+
+### Changed
+
+- Update to use BCs v11.3.0 by default
+  - New file for MOM6 runs
+
 ## [1.24.0] - 2023-08-28
 
 ### Changed

--- a/src/executors/README.md
+++ b/src/executors/README.md
@@ -12,7 +12,7 @@ They have on two optional parameters:
 
 1. `resource_class` which defaults to `large`
 2. `baselibs_version` which defaults to `v7.14.0`
-3. `bcs_version` which defaults to `v11.2.0`
+3. `bcs_version` which defaults to `v11.3.0`
 
 ## See:
  - [Orb Author Intro](https://circleci.com/docs/2.0/orb-author-intro/#section=configuration)

--- a/src/executors/gfortran-bcs.yml
+++ b/src/executors/gfortran-bcs.yml
@@ -12,7 +12,7 @@ parameters:
     type: string
   bcs_version:
     description: "Version of boundary conditions to use"
-    default: v11.2.0
+    default: v11.3.0
     type: string
 
 docker:

--- a/src/executors/ifort-bcs.yml
+++ b/src/executors/ifort-bcs.yml
@@ -12,7 +12,7 @@ parameters:
     type: string
   bcs_version:
     description: "Version of boundary conditions to use"
-    default: v11.2.0
+    default: v11.3.0
     type: string
 
 docker:

--- a/src/jobs/run_gcm.yml
+++ b/src/jobs/run_gcm.yml
@@ -22,7 +22,7 @@ parameters:
     description: "Baselibs version to use"
   bcs_version:
     type: string
-    default: v11.2.0
+    default: v11.3.0
     description: "Boundary condition version to use"
   workspace_root:
     description: "Workspace root"


### PR DESCRIPTION
As it says, we update the default BCs to v11.3.0. This is because MOM6 runs need a new file