### PR TITLE
Update to Open MPI 5.0.0 with GNU

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,8 @@ workflows:
       - shellcheck/check:
           filters: *filters
       - orb-tools/publish:
-          orb-name: geos-esm/circleci-tools
-          vcs-type: << pipeline.project.type >>
+          orb_name: geos-esm/circleci-tools
+          vcs_type: << pipeline.project.type >>
           requires:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           # Use a context to hold your publishing token.
@@ -31,6 +31,6 @@ workflows:
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:
           pipeline-number: << pipeline.number >>
-          vcs-type: << pipeline.project.type >>
+          vcs_type: << pipeline.project.type >>
           requires: [orb-tools/publish]
           filters: *filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,8 @@ workflows:
           filters: *filters
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:
-          pipeline-number: << pipeline.number >>
+          orb_name: geos-esm/circleci-tools
+          pipeline_number: << pipeline.number >>
           vcs_type: << pipeline.project.type >>
           requires: [orb-tools/publish]
           filters: *filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 setup: true
 orbs:
-  orb-tools: circleci/orb-tools@11.1
-  shellcheck: circleci/shellcheck@3.1
+  orb-tools: circleci/orb-tools@12.0
+  shellcheck: circleci/shellcheck@3.2
 
 filters: &filters
   tags:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -24,13 +24,14 @@ workflows:
       - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:
-          orb-name: geos-esm/circleci-tools
-          vcs-type: << pipeline.project.type >>
-          pub-type: production
+          orb_name: geos-esm/circleci-tools
+          vcs_type: << pipeline.project.type >>
+          pub_type: production
           requires:
             - orb-tools/pack
             - integration-test-1
           context: orb-publishing
+          enable_pr_comment: true
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  orb-tools: circleci/orb-tools@11.1
+  orb-tools: circleci/orb-tools@12.0
 filters: &filters
   tags:
     only: /.*/

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -24,9 +24,9 @@ workflows:
       - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:
-          orb_name: geos-esm/circleci-tools
-          vcs_type: << pipeline.project.type >>
-          pub_type: production
+          orb-name: geos-esm/circleci-tools
+          vcs-type: << pipeline.project.type >>
+          pub-type: production
           requires:
             - orb-tools/pack
             - integration-test-1

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -24,9 +24,9 @@ workflows:
       - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:
-          orb-name: geos-esm/circleci-tools
-          vcs-type: << pipeline.project.type >>
-          pub-type: production
+          orb_name: geos-esm/circleci-tools
+          vcs_type: << pipeline.project.type >>
+          pub_type: production
           requires:
             - orb-tools/pack
             - integration-test-1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated the GNU image to use Open MPI 5.0.0
 
+### Fixed
+
+- Fixed some issues with the v12 orb-tools migration
+
 ## [2.0.1] - 2023-12-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [2.1.0] - 2023-12-21
+
+### Changed
+
+- Updated the GNU image to use Open MPI 5.0.0
+
 ## [2.0.1] - 2023-12-01
 
 ### Changed

--- a/src/executors/gfortran.yml
+++ b/src/executors/gfortran.yml
@@ -12,7 +12,7 @@ parameters:
     type: string
 
 docker:
-  - image: gmao/ubuntu20-geos-env-mkl:<< parameters.baselibs_version >>-openmpi_4.1.4-gcc_12.1.0
+  - image: gmao/ubuntu20-geos-env-mkl:<< parameters.baselibs_version >>-openmpi_5.0.0-gcc_12.1.0
     auth:
       username: $DOCKERHUB_USER
       password: $DOCKERHUB_AUTH_TOKEN

--- a/src/executors/gfortran_bcs.yml
+++ b/src/executors/gfortran_bcs.yml
@@ -16,7 +16,7 @@ parameters:
     type: string
 
 docker:
-  - image: gmao/ubuntu20-geos-env-bcs:<< parameters.baselibs_version >>-openmpi_4.1.4-gcc_12.1.0-bcs_<< parameters.bcs_version >>
+  - image: gmao/ubuntu20-geos-env-bcs:<< parameters.baselibs_version >>-openmpi_5.0.0-gcc_12.1.0-bcs_<< parameters.bcs_version >>
     auth:
       username: $DOCKERHUB_USER
       password: $DOCKERHUB_AUTH_TOKEN


### PR DESCRIPTION
Due to changes in MAPL, we need to move to Open MPI 5 to avoid a conflict between `MPI_THREAD_MULTIPLE` and the pt2pt OSC.