### PR TITLE
Add ability to try and checkout the PR branch on fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [2.2.0] - 2024-01-10
+
+### Added
+
+- Added new command `checkout_feature_branch_on_fixture_allow_fail` which will try and checkout the current PRs branch on the fixture. If it fails, it will just continue on.
+
 ## [2.1.0] - 2023-12-21
 
 ### Changed

--- a/src/commands/checkout_feature_branch_on_fixture_allow_fail.yml
+++ b/src/commands/checkout_feature_branch_on_fixture_allow_fail.yml
@@ -1,0 +1,21 @@
+description: "Checkout branch on fixture"
+
+parameters:
+  repo:
+    description: "Name of the repo to act upon"
+    type: string
+    default: GEOSgcm
+  branch:
+    description: "Name of the branch to checkout"
+    type: string
+    default: ""
+
+steps:
+  - run:
+      name: "Checkout branch on fixture"
+      command: |
+        cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.repo >>
+        if [ "${CIRCLE_BRANCH}" != "develop" ] && [ "${CIRCLE_BRANCH}" != "main" ]
+        then
+           git checkout ${CIRCLE_BRANCH} || true
+        fi

--- a/src/commands/checkout_feature_branch_on_fixture_allow_fail.yml
+++ b/src/commands/checkout_feature_branch_on_fixture_allow_fail.yml
@@ -1,4 +1,4 @@
-description: "Checkout branch on fixture"
+description: "Checkout feature branch on fixture, allow failure"
 
 parameters:
   repo:
@@ -12,7 +12,7 @@ parameters:
 
 steps:
   - run:
-      name: "Checkout branch on fixture"
+      name: "Checkout branch on fixture on feature, allow failure"
       command: |
         cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.repo >>
         if [ "${CIRCLE_BRANCH}" != "develop" ] && [ "${CIRCLE_BRANCH}" != "main" ]

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -158,6 +158,11 @@ steps:
         - checkout_branch_on_fixture:
             repo: << parameters.repo >>
             branch: << parameters.fixture_branch >>
+  - unless:
+      condition: << parameters.fixture_branch >>
+      steps:
+        - checkout_feature_branch_on_fixture_allow_fail:
+            repo: << parameters.repo >>
   - mepoclone:
       repo: << parameters.repo >>
   - when:


### PR DESCRIPTION
This PR attempts to add the ability to checkout a PR's branch on the fixture before doing `mepo clone` this is used in PRs like https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/872 where the model can't build because `main` on GEOSgcm does not have needed repos.