### PR TITLE
Move to GCC 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [2.6.0] - 2024-04-04
+
+### Changed
+
+- Updated to GCC 13.2.0 and Open MPI 5.0.2 on the GNU executor
+
 ## [2.5.0] - 2024-04-03
 
 ### Changed

--- a/src/executors/gfortran.yml
+++ b/src/executors/gfortran.yml
@@ -12,7 +12,7 @@ parameters:
     type: string
 
 docker:
-  - image: gmao/ubuntu20-geos-env-mkl:<< parameters.baselibs_version >>-openmpi_5.0.0-gcc_12.1.0
+  - image: gmao/ubuntu20-geos-env-mkl:<< parameters.baselibs_version >>-openmpi_5.0.2-gcc_13.2.0
     auth:
       username: $DOCKERHUB_USER
       password: $DOCKERHUB_AUTH_TOKEN

--- a/src/executors/gfortran_bcs.yml
+++ b/src/executors/gfortran_bcs.yml
@@ -16,7 +16,7 @@ parameters:
     type: string
 
 docker:
-  - image: gmao/ubuntu20-geos-env-bcs:<< parameters.baselibs_version >>-openmpi_5.0.0-gcc_12.1.0-bcs_<< parameters.bcs_version >>
+  - image: gmao/ubuntu20-geos-env-bcs:<< parameters.baselibs_version >>-openmpi_5.0.2-gcc_13.2.0-bcs_<< parameters.bcs_version >>
     auth:
       username: $DOCKERHUB_USER
       password: $DOCKERHUB_AUTH_TOKEN


### PR DESCRIPTION
This PR moves circleci-tools to use GCC 13 images by default.