### PR TITLE
Add option to disable checkout-if-exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [2.7.0] - 2024-04-12
+
+### Added
+
+- Added `checkout_if_exists` option to `build.yml`. This gives the option to turn off `mepo checkout-if-exists` (needed for LDAS workflow). By default, it is `true`.
+
 ## [2.6.0] - 2024-04-04
 
 ### Changed

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -79,6 +79,10 @@ parameters:
     description: "Checkout MAPL branch"
     type: boolean
     default: false
+  checkout_if_exists:
+    description: "Run mepo checkout-if-exists"
+    type: boolean
+    default: true
   persist_workspace:
     description: "Persist the workspace?"
     type: boolean
@@ -186,8 +190,8 @@ steps:
       steps:
         - checkout_mapl_branch:
             repo: << parameters.repo >>
-  - unless:
-      condition: << parameters.checkout_mapl_branch >>
+  - when:
+      condition: << parameters.checkout_if_exists >>
       steps:
         - checkout_if_exists:
             repo: << parameters.repo >>


### PR DESCRIPTION
The GEOSldas workflow uses a `BRIDGE` branch instead of standard GitFlow. After the split out of GEOSldas_GridComp, this exposed an issue because *both* GEOSldas and GEOSldas_GridComp could have `BRIDGE` branches that aren't quite in sync. 

So, this PR gives the ability to disable the `mepo checkout-if-exists` step, though we default to `true`.