### PR TITLE
Update to Baselibs 8.5.0, Intel 2021.13 and Intel MPI 2021.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [3.3.0] - 2024-07-19
+
+### Changed
+
+- Update to Baselibs 8.5.0 by default
+- Update to Intel 2024.2 and Intel 2021.13 by default on the Intel executor
+
 ## [3.2.0] - 2024-06-10
 
 ### Changed

--- a/src/executors/README.md
+++ b/src/executors/README.md
@@ -11,7 +11,7 @@ These are named to match the Fortran compiler.
 They have on two optional parameters:
 
 1. `resource_class` which defaults to `large`
-2. `baselibs_version` which defaults to `v8.0.2`
+2. `baselibs_version` which defaults to `v8.5.0`
 3. `bcs_version` which defaults to `v11.5.0`
 
 ## See:

--- a/src/executors/gfortran.yml
+++ b/src/executors/gfortran.yml
@@ -8,7 +8,7 @@ parameters:
     type: string
   baselibs_version:
     description: "Version of Baselibs to use"
-    default: v8.0.2
+    default: v8.5.0
     type: string
 
 docker:

--- a/src/executors/gfortran_bcs.yml
+++ b/src/executors/gfortran_bcs.yml
@@ -8,7 +8,7 @@ parameters:
     type: string
   baselibs_version:
     description: "Version of Baselibs to use"
-    default: v8.0.2
+    default: v8.5.0
     type: string
   bcs_version:
     description: "Version of boundary conditions to use"

--- a/src/executors/ifort.yml
+++ b/src/executors/ifort.yml
@@ -8,11 +8,11 @@ parameters:
     type: string
   baselibs_version:
     description: "Version of Baselibs to use"
-    default: v8.0.2
+    default: v8.5.0
     type: string
 
 docker:
-  - image: gmao/ubuntu20-geos-env:<< parameters.baselibs_version >>-intelmpi_2021.11-intel_2024.0
+  - image: gmao/ubuntu20-geos-env:<< parameters.baselibs_version >>-intelmpi_2021.13-intel_2024.2
     auth:
       username: $DOCKERHUB_USER
       password: $DOCKERHUB_AUTH_TOKEN

--- a/src/executors/ifort_bcs.yml
+++ b/src/executors/ifort_bcs.yml
@@ -8,7 +8,7 @@ parameters:
     type: string
   baselibs_version:
     description: "Version of Baselibs to use"
-    default: v8.0.2
+    default: v8.5.0
     type: string
   bcs_version:
     description: "Version of boundary conditions to use"
@@ -16,7 +16,7 @@ parameters:
     type: string
 
 docker:
-  - image: gmao/ubuntu20-geos-env-bcs:<< parameters.baselibs_version >>-intelmpi_2021.11-intel_2024.0-bcs_<< parameters.bcs_version >>
+  - image: gmao/ubuntu20-geos-env-bcs:<< parameters.baselibs_version >>-intelmpi_2021.13-intel_2024.2-bcs_<< parameters.bcs_version >>
     auth:
       username: $DOCKERHUB_USER
       password: $DOCKERHUB_AUTH_TOKEN

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -18,7 +18,7 @@ parameters:
     enum: ["medium", "large", "xlarge"]
   baselibs_version:
     type: string
-    default: v8.0.2
+    default: v8.5.0
     description: "Baselibs version to use"
   checkout_fixture:
     type: boolean

--- a/src/jobs/publish_docker.yml
+++ b/src/jobs/publish_docker.yml
@@ -61,7 +61,7 @@ parameters:
     description: "MPI Version on image"
   baselibs_version:
     type: string
-    default: v8.0.2
+    default: v8.5.0
     description: "Baselibs version to use"
   bcs_version:
     type: string

--- a/src/jobs/run_fv3.yml
+++ b/src/jobs/run_fv3.yml
@@ -18,7 +18,7 @@ parameters:
     enum: ["medium", "large", "xlarge"]
   baselibs_version:
     type: string
-    default: v8.0.2
+    default: v8.5.0
     description: "Baselibs version to use"
   workspace_root:
     description: "Workspace root"

--- a/src/jobs/run_gcm.yml
+++ b/src/jobs/run_gcm.yml
@@ -18,7 +18,7 @@ parameters:
     enum: ["medium", "large", "xlarge"]
   baselibs_version:
     type: string
-    default: v8.0.2
+    default: v8.5.0
     description: "Baselibs version to use"
   bcs_version:
     type: string

--- a/src/jobs/run_mapl_tutorial.yml
+++ b/src/jobs/run_mapl_tutorial.yml
@@ -18,7 +18,7 @@ parameters:
     enum: ["medium", "large", "xlarge"]
   baselibs_version:
     type: string
-    default: v8.0.2
+    default: v8.5.0
     description: "Baselibs version to use"
   workspace_root:
     description: "Workspace root"


### PR DESCRIPTION
This PR updates the orb to Baselibs 8.5.0 as well as moving the default Intel versions to ifort 2021.13 and Intel MPI 2021.13