### PR TITLE
v2: Update default BCs to v11.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [2.12.0] - 2024-07-23
+
+### Changed
+
+- Update default BCs to v11.6.0
+
 ## [2.11.0] - 2024-07-19
 
 ### Changed

--- a/src/executors/README.md
+++ b/src/executors/README.md
@@ -12,7 +12,7 @@ They have on two optional parameters:
 
 1. `resource_class` which defaults to `large`
 2. `baselibs_version` which defaults to `v7.25.0`
-3. `bcs_version` which defaults to `v11.5.0`
+3. `bcs_version` which defaults to `v11.6.0`
 
 ## See:
  - [Orb Author Intro](https://circleci.com/docs/2.0/orb-author-intro/#section=configuration)

--- a/src/executors/gfortran_bcs.yml
+++ b/src/executors/gfortran_bcs.yml
@@ -12,7 +12,7 @@ parameters:
     type: string
   bcs_version:
     description: "Version of boundary conditions to use"
-    default: v11.5.0
+    default: v11.6.0
     type: string
 
 docker:

--- a/src/executors/ifort_bcs.yml
+++ b/src/executors/ifort_bcs.yml
@@ -12,7 +12,7 @@ parameters:
     type: string
   bcs_version:
     description: "Version of boundary conditions to use"
-    default: v11.5.0
+    default: v11.6.0
     type: string
 
 docker:

--- a/src/jobs/run_gcm.yml
+++ b/src/jobs/run_gcm.yml
@@ -22,7 +22,7 @@ parameters:
     description: "Baselibs version to use"
   bcs_version:
     type: string
-    default: v11.5.0
+    default: v11.6.0
     description: "Boundary condition version to use"
   workspace_root:
     description: "Workspace root"


### PR DESCRIPTION
This updates the default BCs to v11.6.0. This is mainly for R21C work, but might as well update it for future work as well.