### PR TITLE
Update to BCs v12 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.1.0] - 2024-09-09
+
+### Changed
+
+- Move to use BCs v12.0.0 by default
+  - Directory for these is `TinyBCs-GitV12`
+  - Move to 181 levels by default
+
 ## [5.0.0] - 2024-08-23
 
 Note: This is a major version bump due to the change from `intel` to `ifort` and `ifx` executors.

--- a/src/commands/create_gcm_expt.yml
+++ b/src/commands/create_gcm_expt.yml
@@ -20,7 +20,7 @@ parameters:
   gcm_vert_resolution:
     description: "Vertical resolution for gcm experiment"
     type: integer
-    default: 72
+    default: 181
   gcm_ocean_type:
     description: "Ocean type for gcm experiment"
     type: enum
@@ -34,5 +34,5 @@ steps:
         TERM: dumb
       command: |
         cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.workspace_root >>/install-<< parameters.repo >>/bin
-        /TinyBCs-GitV10/scripts/create_expt.py << parameters.gcm_experiment_name >> --expdir ${CIRCLE_WORKING_DIRECTORY}/<< parameters.workspace_root >> --horz << parameters.gcm_horz_resolution >> --vert << parameters.gcm_vert_resolution >> --ocean << parameters.gcm_ocean_type >>
+        /TinyBCs-GitV12/scripts/create_expt.py << parameters.gcm_experiment_name >> --expdir ${CIRCLE_WORKING_DIRECTORY}/<< parameters.workspace_root >> --horz << parameters.gcm_horz_resolution >> --vert << parameters.gcm_vert_resolution >> --ocean << parameters.gcm_ocean_type >>
 

--- a/src/commands/run_makeoneday.yml
+++ b/src/commands/run_makeoneday.yml
@@ -26,7 +26,7 @@ steps:
             name: "Run makeoneday, change layout to 1x6"
             command: |
               cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.workspace_root >>/<< parameters.gcm_experiment_name >>
-              /TinyBCs-GitV10/scripts/makeoneday.bash 1hr nxy 1 6 noext
+              /TinyBCs-GitV12/scripts/makeoneday.bash 1hr nxy 1 6 noext
   - unless:
       condition: << parameters.change_layout >>
       steps:
@@ -34,4 +34,4 @@ steps:
             name: "Run makeoneday"
             command: |
               cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.workspace_root >>/<< parameters.gcm_experiment_name >>
-              /TinyBCs-GitV10/scripts/makeoneday.bash 1hr noext
+              /TinyBCs-GitV12/scripts/makeoneday.bash 1hr noext

--- a/src/executors/README.md
+++ b/src/executors/README.md
@@ -13,7 +13,7 @@ They have on two optional parameters:
 
 1. `resource_class` which defaults to `large`
 2. `baselibs_version` which defaults to `v8.5.0`
-3. `bcs_version` which defaults to `v11.6.0`
+3. `bcs_version` which defaults to `v12.0.0`
 
 ## See:
  - [Orb Author Intro](https://circleci.com/docs/2.0/orb-author-intro/#section=configuration)

--- a/src/executors/gfortran_bcs.yml
+++ b/src/executors/gfortran_bcs.yml
@@ -12,7 +12,7 @@ parameters:
     type: string
   bcs_version:
     description: "Version of boundary conditions to use"
-    default: v11.6.0
+    default: v12.0.0
     type: string
 
 docker:

--- a/src/executors/ifort_bcs.yml
+++ b/src/executors/ifort_bcs.yml
@@ -12,7 +12,7 @@ parameters:
     type: string
   bcs_version:
     description: "Version of boundary conditions to use"
-    default: v11.6.0
+    default: v12.0.0
     type: string
 
 docker:

--- a/src/executors/ifx_bcs.yml
+++ b/src/executors/ifx_bcs.yml
@@ -12,7 +12,7 @@ parameters:
     type: string
   bcs_version:
     description: "Version of boundary conditions to use"
-    default: v11.6.0
+    default: v12.0.0
     type: string
 
 docker:

--- a/src/jobs/run_gcm.yml
+++ b/src/jobs/run_gcm.yml
@@ -22,7 +22,7 @@ parameters:
     description: "Baselibs version to use"
   bcs_version:
     type: string
-    default: v11.6.0
+    default: v12.0.0
     description: "Boundary condition version to use"
   workspace_root:
     description: "Workspace root"
@@ -39,7 +39,7 @@ parameters:
   gcm_vert_resolution:
     description: "Vertical resolution for gcm experiment"
     type: integer
-    default: 72
+    default: 181
   gcm_ocean_type:
     description: "Ocean type for gcm experiment"
     type: enum


### PR DESCRIPTION
Move to BCs v12 by default. Also moves to L181 by default.