### PR TITLE
v5: Update to Baselibs 8.7.0 default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.3.0] - 2024-10-24
+
+### Changed
+
+- Move to use Baselibs 8.7.0 by default
+
+## [5.2.0] - 2024-09-19
+
+### Changed
+
+- Move to use Baselibs 8.6.0 by default
+
 ## [5.1.0] - 2024-09-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [5.3.0] - 2024-10-24
+## [5.3.0] - 2024-10-28
 
 ### Changed
 

--- a/src/executors/README.md
+++ b/src/executors/README.md
@@ -12,7 +12,7 @@ These are named to match the Fortran compiler.
 They have on two optional parameters:
 
 1. `resource_class` which defaults to `large`
-2. `baselibs_version` which defaults to `v8.5.0`
+2. `baselibs_version` which defaults to `v8.7.0`
 3. `bcs_version` which defaults to `v12.0.0`
 
 ## See:

--- a/src/executors/gfortran.yml
+++ b/src/executors/gfortran.yml
@@ -8,7 +8,7 @@ parameters:
     type: string
   baselibs_version:
     description: "Version of Baselibs to use"
-    default: v8.5.0
+    default: v8.7.0
     type: string
 
 docker:

--- a/src/executors/gfortran_bcs.yml
+++ b/src/executors/gfortran_bcs.yml
@@ -8,7 +8,7 @@ parameters:
     type: string
   baselibs_version:
     description: "Version of Baselibs to use"
-    default: v8.5.0
+    default: v8.7.0
     type: string
   bcs_version:
     description: "Version of boundary conditions to use"

--- a/src/executors/ifort.yml
+++ b/src/executors/ifort.yml
@@ -8,7 +8,7 @@ parameters:
     type: string
   baselibs_version:
     description: "Version of Baselibs to use"
-    default: v8.5.0
+    default: v8.7.0
     type: string
 
 docker:

--- a/src/executors/ifort_bcs.yml
+++ b/src/executors/ifort_bcs.yml
@@ -8,7 +8,7 @@ parameters:
     type: string
   baselibs_version:
     description: "Version of Baselibs to use"
-    default: v8.5.0
+    default: v8.7.0
     type: string
   bcs_version:
     description: "Version of boundary conditions to use"

--- a/src/executors/ifx.yml
+++ b/src/executors/ifx.yml
@@ -8,7 +8,7 @@ parameters:
     type: string
   baselibs_version:
     description: "Version of Baselibs to use"
-    default: v8.5.0
+    default: v8.7.0
     type: string
 
 docker:

--- a/src/executors/ifx_bcs.yml
+++ b/src/executors/ifx_bcs.yml
@@ -8,7 +8,7 @@ parameters:
     type: string
   baselibs_version:
     description: "Version of Baselibs to use"
-    default: v8.5.0
+    default: v8.7.0
     type: string
   bcs_version:
     description: "Version of boundary conditions to use"

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -18,7 +18,7 @@ parameters:
     enum: ["medium", "large", "xlarge"]
   baselibs_version:
     type: string
-    default: v8.5.0
+    default: v8.7.0
     description: "Baselibs version to use"
   checkout_fixture:
     type: boolean

--- a/src/jobs/publish_docker.yml
+++ b/src/jobs/publish_docker.yml
@@ -61,7 +61,7 @@ parameters:
     description: "MPI Version on image"
   baselibs_version:
     type: string
-    default: v8.5.0
+    default: v8.7.0
     description: "Baselibs version to use"
   bcs_version:
     type: string

--- a/src/jobs/run_fv3.yml
+++ b/src/jobs/run_fv3.yml
@@ -18,7 +18,7 @@ parameters:
     enum: ["medium", "large", "xlarge"]
   baselibs_version:
     type: string
-    default: v8.5.0
+    default: v8.7.0
     description: "Baselibs version to use"
   workspace_root:
     description: "Workspace root"

--- a/src/jobs/run_gcm.yml
+++ b/src/jobs/run_gcm.yml
@@ -18,7 +18,7 @@ parameters:
     enum: ["medium", "large", "xlarge"]
   baselibs_version:
     type: string
-    default: v8.5.0
+    default: v8.7.0
     description: "Baselibs version to use"
   bcs_version:
     type: string

--- a/src/jobs/run_mapl_tutorial.yml
+++ b/src/jobs/run_mapl_tutorial.yml
@@ -18,7 +18,7 @@ parameters:
     enum: ["medium", "large", "xlarge"]
   baselibs_version:
     type: string
-    default: v8.5.0
+    default: v8.7.0
     description: "Baselibs version to use"
   workspace_root:
     description: "Workspace root"


### PR DESCRIPTION
This updates v5 to use Baselibs 8.7.0 by default