### PR TITLE
v5: Update to GCC 14 in GCC executors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.4.0] - 2024-10-31
+
+### Changed
+
+- Move to use GCC 14.2 and Open MPI 5.0.5 in GNU executor
+
 ## [5.3.0] - 2024-10-28
 
 ### Changed

--- a/src/executors/gfortran.yml
+++ b/src/executors/gfortran.yml
@@ -12,7 +12,7 @@ parameters:
     type: string
 
 docker:
-  - image: gmao/ubuntu20-geos-env-mkl:<< parameters.baselibs_version >>-openmpi_5.0.2-gcc_13.2.0
+  - image: gmao/ubuntu20-geos-env-mkl:<< parameters.baselibs_version >>-openmpi_5.0.5-gcc_14.2.0
     auth:
       username: $DOCKERHUB_USER
       password: $DOCKERHUB_AUTH_TOKEN

--- a/src/executors/gfortran_bcs.yml
+++ b/src/executors/gfortran_bcs.yml
@@ -16,7 +16,7 @@ parameters:
     type: string
 
 docker:
-  - image: gmao/ubuntu20-geos-env-bcs:<< parameters.baselibs_version >>-openmpi_5.0.2-gcc_13.2.0-bcs_<< parameters.bcs_version >>
+  - image: gmao/ubuntu20-geos-env-bcs:<< parameters.baselibs_version >>-openmpi_5.0.5-gcc_14.2.0-bcs_<< parameters.bcs_version >>
     auth:
       username: $DOCKERHUB_USER
       password: $DOCKERHUB_AUTH_TOKEN


### PR DESCRIPTION
This PR updates v5 orb to use GCC 14 in the GCC executors