### PR TITLE
v4: Add remove_pfunit option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.3.0] - 2024-11-07
+
+### Added
+
+- Added new `remove_pfunit` option to the build job to remove PFUnit from the build (allowing testing of an edge case in MAPL)
+
 ## [4.2.0] - 2024-10-31
 
 ### Changed

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -103,6 +103,10 @@ parameters:
     description: "Remove pFlogger from Baselibs"
     type: boolean
     default: false
+  remove_pfunit:
+    description: "Remove pFUnit from Baselibs"
+    type: boolean
+    default: false
 
 
 executor:
@@ -147,6 +151,21 @@ steps:
             # 1. delete any directory that starts with PFLOGGER
             command: |
               find /baselibs/ -type d -name PFLOGGER* -exec rm -rf {} +
+
+  # For some cases to be correctly handled, we need to remove pFUnit from Baselibs
+  - when:
+      condition: << parameters.remove_pfunit >>
+      steps:
+        - run:
+            name: Remove pFUnit from Baselibs
+            # We now need to delete files from the baselibs
+            # install but we don't know the exact path (different on
+            # different executors). So we use find to locate the
+            # files and then delete them.
+            #
+            # 1. delete any directory that starts with PFUNIT
+            command: |
+              find /baselibs/ -type d -name PFUNIT* -exec rm -rf {} +
 
   # If we have to checkout a fixture, do that...
   - when:


### PR DESCRIPTION
An edge case was found where a commit to MAPL created a CMake failure when building without pFUnit. This will let us test that case.