### PR TITLE
v4: Update to ifx 2025.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.4.0] - 2024-11-19
+
+### Changed
+
+- Updated ifx exectuor to use Intel 2025.0 and Intel MPI 2021.14
+
 ## [4.3.0] - 2024-11-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated ifx exectuor to use Intel 2025.0 and Intel MPI 2021.14
+- Updated ifx executor to use Intel 2025.0 and Intel MPI 2021.14
 
 ## [4.3.0] - 2024-11-07
 

--- a/src/executors/ifx.yml
+++ b/src/executors/ifx.yml
@@ -12,7 +12,7 @@ parameters:
     type: string
 
 docker:
-  - image: gmao/ubuntu20-geos-env:<< parameters.baselibs_version >>-intelmpi_2021.13-ifx_2024.2
+  - image: gmao/ubuntu20-geos-env:<< parameters.baselibs_version >>-intelmpi_2021.14-ifx_2025.0
     auth:
       username: $DOCKERHUB_USER
       password: $DOCKERHUB_AUTH_TOKEN

--- a/src/executors/ifx_bcs.yml
+++ b/src/executors/ifx_bcs.yml
@@ -16,7 +16,7 @@ parameters:
     type: string
 
 docker:
-  - image: gmao/ubuntu20-geos-env-bcs:<< parameters.baselibs_version >>-intelmpi_2021.13-ifx_2024.2-bcs_<< parameters.bcs_version >>
+  - image: gmao/ubuntu20-geos-env-bcs:<< parameters.baselibs_version >>-intelmpi_2021.14-ifx_2025.0-bcs_<< parameters.bcs_version >>
     auth:
       username: $DOCKERHUB_USER
       password: $DOCKERHUB_AUTH_TOKEN


### PR DESCRIPTION
This PR updates the ifx executor to use ifx 2025.0 and Intel MPI 2021.14