### PR TITLE
v5: Use xlarge by default for builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.7.0] - 2024-11-26
+
+### Changed
+
+- The build job now defaults to the `xlarge` resource class. It was found `ifx` jobs required more memory.
+
 ## [5.6.0] - 2024-11-19
 
 ### Changed

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -13,7 +13,7 @@ parameters:
     enum: ["ifort", "gfortran", "ifx"]
   resource_class:
     type: enum
-    default: large
+    default: xlarge
     description: "Resource class to use"
     enum: ["medium", "large", "xlarge"]
   baselibs_version:


### PR DESCRIPTION
This PR updates v4 to use the `xlarge` resource class for build jobs. This is needed for `ifx` CI testing it was found.