### PR TITLE
v4: Add build_type to run_mapl_tutorial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [4.8.0] - 2025-01-17
+
+### Changed
+
 - Added `build_type` to `run_mapl_tutorial` for matrix purposes
 
 ## [4.7.0] - 2025-01-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added `build_type` to `run_mapl_tutorial` for matrix purposes
+
 ## [4.7.0] - 2025-01-15
 
 ### Changed

--- a/src/jobs/run_mapl_tutorial.yml
+++ b/src/jobs/run_mapl_tutorial.yml
@@ -27,6 +27,11 @@ parameters:
   tutorial_name:
     description: "Name of tutorial"
     type: string
+  build_type:
+    description: Build type for CMake. Must be one of "Debug", "Release", or "Aggressive"
+    type: enum
+    default: "Debug"
+    enum: ["Debug", "Release", "Aggressive"]
 
 executor:
   name: << parameters.compiler >>


### PR DESCRIPTION
This adds the ability to use `build_type` matrices with `run_mapl_tutorial`