### PR TITLE
v5: Add build_type to run_mapl_tutorial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+## [5.10.0] - 2025-01-17
+
+### Changed
+
+- Added `build_type` to `run_mapl_tutorial` for matrix purposes
+
 ## [5.9.0] - 2025-01-16
 
 ### Changed

--- a/src/jobs/run_mapl_tutorial.yml
+++ b/src/jobs/run_mapl_tutorial.yml
@@ -27,6 +27,11 @@ parameters:
   tutorial_name:
     description: "Name of tutorial"
     type: string
+  build_type:
+    description: Build type for CMake. Must be one of "Debug", "Release", or "Aggressive"
+    type: enum
+    default: "Debug"
+    enum: ["Debug", "Release", "Aggressive"]
 
 executor:
   name: << parameters.compiler >>


### PR DESCRIPTION
This adds the ability to use `build_type` matrices with `run_mapl_tutorial`