### PR TITLE
v5: Revert to large executor for builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [5.15.0] - 2025-04-07
+
+### Changed
+
+- Revert to using `large` resource class for the build job (was doubling costs unnecessarily)
+
 ## [5.14.0] - 2025-02-12
 
 ### Changed

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -13,7 +13,7 @@ parameters:
     enum: ["ifort", "gfortran", "ifx"]
   resource_class:
     type: enum
-    default: xlarge
+    default: large
     description: "Resource class to use"
     enum: ["medium", "large", "xlarge"]
   baselibs_version:


### PR DESCRIPTION
Revert back to large executor for builds. Saves on cost.