### PR TITLE
v5: Revert to v12 land bcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -7,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
+## [5.18.0] - 2025-06.30
+
+### Changed
+
+- Move back to v12 land for boundary conditions
+  - This is due to the v13 BCS not being ready for use in production yet
 
 ## [5.17.0] - 2025-05-06
 

--- a/src/commands/create_gcm_expt.yml
+++ b/src/commands/create_gcm_expt.yml
@@ -29,8 +29,8 @@ parameters:
   landbcs_type:
     description: "Land BCs type for gcm experiment"
     type: enum
-    enum: ["NL3", "v13"]
-    default: v13
+    enum: ["NL3", "v12", "v13"]
+    default: v12
 
 steps:
   - run:

--- a/src/jobs/run_gcm.yml
+++ b/src/jobs/run_gcm.yml
@@ -48,8 +48,8 @@ parameters:
   landbcs_type:
     description: "Land BCs type for gcm experiment"
     type: enum
-    enum: ["NL3", "v13"]
-    default: v13
+    enum: ["NL3", "v12", "v13"]
+    default: v12
   change_layout:
     description: "Change layout to 1x6 (true for amip, false for coupled)"
     type: boolean


### PR DESCRIPTION
Recently GEOSgcm v12 has reverted to the v12 BCs. We need to update the orb.