### PR TITLE
v5: Add gen2 as allowed resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added ability to use gen2 resources
+
 ## [5.29.0] - 2026-06-02
 
 ### Changed

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -15,7 +15,7 @@ parameters:
     type: enum
     default: large
     description: "Resource class to use"
-    enum: ["medium", "large", "xlarge"]
+    enum: ["medium", "large", "xlarge", "medium.gen2", "large.gen2", "xlarge.gen2"]
   baselibs_version:
     type: string
     default: v8.32.0

--- a/src/jobs/publish_docker.yml
+++ b/src/jobs/publish_docker.yml
@@ -31,7 +31,7 @@ parameters:
     type: enum
     default: large
     description: "Resource class to use"
-    enum: ["medium", "large", "xlarge"]
+    enum: ["medium", "large", "xlarge", "medium.gen2", "large.gen2", "xlarge.gen2"]
   os_version:
     type: enum
     default: ubuntu24

--- a/src/jobs/run_fv3.yml
+++ b/src/jobs/run_fv3.yml
@@ -15,7 +15,7 @@ parameters:
     type: enum
     default: large
     description: "Resource class to use"
-    enum: ["medium", "large", "xlarge"]
+    enum: ["medium", "large", "xlarge", "medium.gen2", "large.gen2", "xlarge.gen2"]
   baselibs_version:
     type: string
     default: v8.32.0

--- a/src/jobs/run_gcm.yml
+++ b/src/jobs/run_gcm.yml
@@ -15,7 +15,7 @@ parameters:
     type: enum
     default: xlarge
     description: "Resource class to use"
-    enum: ["medium", "large", "xlarge"]
+    enum: ["medium", "large", "xlarge", "medium.gen2", "large.gen2", "xlarge.gen2"]
   baselibs_version:
     type: string
     default: v8.32.0

--- a/src/jobs/run_gocart_tests.yml
+++ b/src/jobs/run_gocart_tests.yml
@@ -16,7 +16,7 @@ parameters:
     type: enum
     default: xlarge
     description: "Resource class to use"
-    enum: ["medium", "large", "xlarge"]
+    enum: ["medium", "large", "xlarge", "medium.gen2", "large.gen2", "xlarge.gen2"]
   baselibs_version:
     type: string
     default: v8.32.0

--- a/src/jobs/run_mapl_tutorial.yml
+++ b/src/jobs/run_mapl_tutorial.yml
@@ -15,7 +15,7 @@ parameters:
     type: enum
     default: medium
     description: "Resource class to use"
-    enum: ["medium", "large", "xlarge"]
+    enum: ["medium", "large", "xlarge", "medium.gen2", "large.gen2", "xlarge.gen2"]
   baselibs_version:
     type: string
     default: v8.32.0


### PR DESCRIPTION
This PR adds the ability to use gen2 resources:

https://circleci.com/docs/guides/execution-managed/using-docker/#docker-gen2-benefits

---


I did some tests with MAPL.

Assuming **`test-ci-2026Jun17` = Gen1** and **`feature/v2-tryout-gen2-try2` = Gen2**, here’s the comparison. “Speedup” is `Gen1 time / Gen2 time`, so values above `1.00x` mean Gen2 was faster.

| Workflow / Job | Gen1 time | Gen2 time | Speedup | Time change |
|---|---:|---:|---:|---:|
| **Workflow: build-GEOSldas** | 15:14 | 11:36 | **1.31x** | **23.9% faster** |
| build-GEOSldas-on-ifort | 6:55 | 7:57 | 0.87x | 14.9% slower |
| build-GEOSldas-on-gfortran | 15:13 | 11:35 | **1.31x** | **23.9% faster** |
| **Workflow: build-and-run-GEOSgcm** | 28:58 | 28:36 | 1.01x | 1.3% faster |
| build-GEOSgcm-on-ifort | 18:16 | 21:49 | 0.84x | 19.4% slower |
| run-GCM-on-ifort | 4:52 | 4:33 | 1.07x | 6.5% faster |
| run-coupled-GCM-on-ifort | 7:57 | 6:13 | **1.28x** | **21.8% faster** |
| build-GEOSgcm-on-gfortran | 25:16 | 25:33 | 0.99x | 1.1% slower |
| run-GCM-on-gfortran | 3:39 | 3:00 | **1.22x** | **17.8% faster** |
| **Workflow: build-and-test-MAPL** | 8:17 | 7:30 | **1.10x** | **9.5% faster** |
| build-and-test-MAPL-as-Debug-on-ifort-using-Unix Makefiles | 6:58 | 6:19 | **1.10x** | **9.3% faster** |
| run-hello_world-Tutorial-with-ifort-built-with-Debug | 1:07 | 1:08 | 0.99x | 1.5% slower |
| run-parent_no_children-Tutorial-with-ifort-built-with-Debug | 1:13 | 1:02 | **1.18x** | **15.1% faster** |
| run-parent_one_child_import_via_extdata-Tutorial-with-ifort-built-with-Debug | 1:07 | 0:59 | **1.14x** | **11.9% faster** |
| run-parent_one_child_no_imports-Tutorial-with-ifort-built-with-Debug | 1:09 | 0:55 | **1.25x** | **20.3% faster** |
| run-parent_two_siblings_connect_import_export-Tutorial-with-ifort-built-with-Debug | 1:04 | 0:58 | **1.10x** | **9.4% faster** |

Main takeaway: **Gen2 helps some runtime/test jobs and the GEOSldas gfortran build a lot**, but it is **not uniformly faster for compilation**. The big red flag is:

| Job | Gen1 | Gen2 | Result |
|---|---:|---:|---:|
| build-GEOSgcm-on-ifort | 18:16 | 21:49 | **19.4% slower on Gen2** |
| build-GEOSldas-on-ifort | 6:55 | 7:57 | **14.9% slower on Gen2** |

So for your actual wall-clock workflows, the benefit looks like:

| Workflow | Net benefit |
|---|---:|
| build-GEOSldas | **~24% faster** |
| build-and-run-GEOSgcm | **basically unchanged** |
| build-and-test-MAPL | **~9.5% faster** |

My read: Gen2 looks promising for the smaller MAPL tests and some run steps, but for GEOSgcm the critical path is still the gfortran build at ~25.5 minutes, so the whole workflow barely moves. For ifort-heavy build jobs, this one sample actually looks worse on Gen2.