### PR TITLE
v5: Update branch exclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.30.0] - 2026-06-05
+
+### Changed
+
+- Branch exclusion commands (`checkout_mapl_branch`, `checkout_if_exists`, `checkout_feature_branch_on_fixture_allow_fail`) now also skip feature-branch checkout logic for `release/v*` branches
+
 ## [5.29.0] - 2026-06-02
 
 ### Changed

--- a/src/commands/checkout_feature_branch_on_fixture_allow_fail.yml
+++ b/src/commands/checkout_feature_branch_on_fixture_allow_fail.yml
@@ -15,7 +15,7 @@ steps:
       name: "Checkout branch on fixture on feature, allow failure"
       command: |
         cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.repo >>
-        if [ "${CIRCLE_BRANCH}" != "develop" ] && [ "${CIRCLE_BRANCH}" != "main" ]
+        if [ "${CIRCLE_BRANCH}" != "develop" ] && [ "${CIRCLE_BRANCH}" != "main" ] && [[ "${CIRCLE_BRANCH}" != release/v* ]]
         then
            git checkout ${CIRCLE_BRANCH} || true
         fi

--- a/src/commands/checkout_if_exists.yml
+++ b/src/commands/checkout_if_exists.yml
@@ -12,7 +12,7 @@ steps:
       command: |
         cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.repo >>
         echo "Branch: ${CIRCLE_BRANCH}"
-        if [ "${CIRCLE_BRANCH}" != "develop" ] && [ "${CIRCLE_BRANCH}" != "main" ]
+        if [ "${CIRCLE_BRANCH}" != "develop" ] && [ "${CIRCLE_BRANCH}" != "main" ] && [[ "${CIRCLE_BRANCH}" != release/v* ]]
         then
            mepo checkout-if-exists ${CIRCLE_BRANCH}
         else

--- a/src/commands/checkout_mapl_branch.yml
+++ b/src/commands/checkout_mapl_branch.yml
@@ -26,7 +26,7 @@ steps:
         fi
 
         mepo checkout ${CIRCLE_BRANCH} MAPL
-        if [ "${CIRCLE_BRANCH}" != "develop" ] && [ "${CIRCLE_BRANCH}" != "main" ]
+        if [ "${CIRCLE_BRANCH}" != "develop" ] && [ "${CIRCLE_BRANCH}" != "main" ] && [[ "${CIRCLE_BRANCH}" != release/v* ]]
         then
             mepo checkout-if-exists ${CIRCLE_BRANCH}
         fi


### PR DESCRIPTION
This PR updates some of the "don't do this" commands to work on `release/v*` branches along with `main` and `develop` since `release/v*` branches are "like those"