### PR TITLE
v6: Determine build CPU count dynamically via cgroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Determine build CPU count dynamically using cgroups (v1/v2 CFS limit) instead of physical host CPU count (`nproc`), preventing out-of-memory and CPU-throttling issues on CircleCI runners
+
 ## [6.9.0] - 2026-06-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.10.0] - 2026-06-17
+
 ### Changed
 
 - Determine build CPU count dynamically using cgroups (v1/v2 CFS limit) instead of physical host CPU count (`nproc`), preventing out-of-memory and CPU-throttling issues on CircleCI runners

--- a/src/commands/buildinstall.yml
+++ b/src/commands/buildinstall.yml
@@ -25,8 +25,27 @@ steps:
         - run:
             name: "Build and install - GNU Make"
             command: |
+              # Determine actual number of available vCPUs
+              num_procs=""
+              if [ -f /sys/fs/cgroup/cpu.max ]; then
+                read -r quota period < /sys/fs/cgroup/cpu.max
+                if [ "$quota" != "max" ] && [ "$period" -gt 0 ]; then
+                  num_procs=$(( quota / period ))
+                fi
+              elif [ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us ] && [ -f /sys/fs/cgroup/cpu/cpu.cfs_period_us ]; then
+                quota=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
+                period=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)
+                if [ "$quota" -gt 0 ] && [ "$period" -gt 0 ]; then
+                  num_procs=$(( quota / period ))
+                fi
+              fi
+              if [ -z "$num_procs" ] || [ "$num_procs" -le 0 ]; then
+                num_procs=$(nproc)
+              fi
+              echo "Building with $num_procs processes..."
+
               cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-<< parameters.repo >>
-              make -j "$(nproc)" install |& tee /logfiles/make.log || make -j << parameters.rebuild_procs >> install |& tee /logfiles/make-retry.log
+              make -j "$num_procs" install |& tee /logfiles/make.log || make -j << parameters.rebuild_procs >> install |& tee /logfiles/make-retry.log
   - unless:
       condition:
         matches:
@@ -36,5 +55,24 @@ steps:
         - run:
             name: "Build and install - Ninja"
             command: |
+              # Determine actual number of available vCPUs
+              num_procs=""
+              if [ -f /sys/fs/cgroup/cpu.max ]; then
+                read -r quota period < /sys/fs/cgroup/cpu.max
+                if [ "$quota" != "max" ] && [ "$period" -gt 0 ]; then
+                  num_procs=$(( quota / period ))
+                fi
+              elif [ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us ] && [ -f /sys/fs/cgroup/cpu/cpu.cfs_period_us ]; then
+                quota=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
+                period=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)
+                if [ "$quota" -gt 0 ] && [ "$period" -gt 0 ]; then
+                  num_procs=$(( quota / period ))
+                fi
+              fi
+              if [ -z "$num_procs" ] || [ "$num_procs" -le 0 ]; then
+                num_procs=$(nproc)
+              fi
+              echo "Building with $num_procs processes..."
+
               cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-<< parameters.repo >>
-              ninja -j "$(nproc)" install |& tee /logfiles/ninja.log || ninja -j << parameters.rebuild_procs >> install |& tee /logfiles/ninja-retry.log
+              ninja -j "$num_procs" install |& tee /logfiles/ninja.log || ninja -j << parameters.rebuild_procs >> install |& tee /logfiles/ninja-retry.log

--- a/src/commands/buildtarget.yml
+++ b/src/commands/buildtarget.yml
@@ -28,8 +28,27 @@ steps:
         - run:
             name: "Build target << parameters.target >> (retry after fail) - GNU Make"
             command: |
+              # Determine actual number of available vCPUs
+              num_procs=""
+              if [ -f /sys/fs/cgroup/cpu.max ]; then
+                read -r quota period < /sys/fs/cgroup/cpu.max
+                if [ "$quota" != "max" ] && [ "$period" -gt 0 ]; then
+                  num_procs=$(( quota / period ))
+                fi
+              elif [ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us ] && [ -f /sys/fs/cgroup/cpu/cpu.cfs_period_us ]; then
+                quota=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
+                period=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)
+                if [ "$quota" -gt 0 ] && [ "$period" -gt 0 ]; then
+                  num_procs=$(( quota / period ))
+                fi
+              fi
+              if [ -z "$num_procs" ] || [ "$num_procs" -le 0 ]; then
+                num_procs=$(nproc)
+              fi
+              echo "Building with $num_procs processes..."
+
               cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-<< parameters.repo >>
-              make -j "$(nproc)" << parameters.target >> |& tee /logfiles/make.log || make -j << parameters.rebuild_procs >> << parameters.target >> |& tee /logfiles/make-retry.log
+              make -j "$num_procs" << parameters.target >> |& tee /logfiles/make.log || make -j << parameters.rebuild_procs >> << parameters.target >> |& tee /logfiles/make-retry.log
 
   - unless:
       condition:
@@ -40,5 +59,24 @@ steps:
         - run:
             name: "Build target << parameters.target >> (retry after fail) - Ninja"
             command: |
+              # Determine actual number of available vCPUs
+              num_procs=""
+              if [ -f /sys/fs/cgroup/cpu.max ]; then
+                read -r quota period < /sys/fs/cgroup/cpu.max
+                if [ "$quota" != "max" ] && [ "$period" -gt 0 ]; then
+                  num_procs=$(( quota / period ))
+                fi
+              elif [ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us ] && [ -f /sys/fs/cgroup/cpu/cpu.cfs_period_us ]; then
+                quota=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
+                period=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)
+                if [ "$quota" -gt 0 ] && [ "$period" -gt 0 ]; then
+                  num_procs=$(( quota / period ))
+                fi
+              fi
+              if [ -z "$num_procs" ] || [ "$num_procs" -le 0 ]; then
+                num_procs=$(nproc)
+              fi
+              echo "Building with $num_procs processes..."
+
               cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-<< parameters.repo >>
-              ninja -j "$(nproc)" << parameters.target >> |& tee /logfiles/ninja.log || ninja -j << parameters.rebuild_procs >> << parameters.target >> |& tee /logfiles/ninja-retry.log
+              ninja -j "$num_procs" << parameters.target >> |& tee /logfiles/ninja.log || ninja -j << parameters.rebuild_procs >> << parameters.target >> |& tee /logfiles/ninja-retry.log

--- a/src/commands/buildtests.yml
+++ b/src/commands/buildtests.yml
@@ -25,8 +25,27 @@ steps:
         - run:
             name: "Build tests - GNU Make"
             command: |
+              # Determine actual number of available vCPUs
+              num_procs=""
+              if [ -f /sys/fs/cgroup/cpu.max ]; then
+                read -r quota period < /sys/fs/cgroup/cpu.max
+                if [ "$quota" != "max" ] && [ "$period" -gt 0 ]; then
+                  num_procs=$(( quota / period ))
+                fi
+              elif [ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us ] && [ -f /sys/fs/cgroup/cpu/cpu.cfs_period_us ]; then
+                quota=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
+                period=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)
+                if [ "$quota" -gt 0 ] && [ "$period" -gt 0 ]; then
+                  num_procs=$(( quota / period ))
+                fi
+              fi
+              if [ -z "$num_procs" ] || [ "$num_procs" -le 0 ]; then
+                num_procs=$(nproc)
+              fi
+              echo "Building with $num_procs processes..."
+
               cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-<< parameters.repo >>
-              make -j "$(nproc)" build-tests |& tee /logfiles/build-tests.log || make -j << parameters.rebuild_procs >> build-tests |& tee /logfiles/build-tests-retry.log
+              make -j "$num_procs" build-tests |& tee /logfiles/build-tests.log || make -j << parameters.rebuild_procs >> build-tests |& tee /logfiles/build-tests-retry.log
 
   - unless:
       condition:
@@ -37,5 +56,24 @@ steps:
         - run:
             name: "Build tests - Ninja"
             command: |
+              # Determine actual number of available vCPUs
+              num_procs=""
+              if [ -f /sys/fs/cgroup/cpu.max ]; then
+                read -r quota period < /sys/fs/cgroup/cpu.max
+                if [ "$quota" != "max" ] && [ "$period" -gt 0 ]; then
+                  num_procs=$(( quota / period ))
+                fi
+              elif [ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us ] && [ -f /sys/fs/cgroup/cpu/cpu.cfs_period_us ]; then
+                quota=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
+                period=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)
+                if [ "$quota" -gt 0 ] && [ "$period" -gt 0 ]; then
+                  num_procs=$(( quota / period ))
+                fi
+              fi
+              if [ -z "$num_procs" ] || [ "$num_procs" -le 0 ]; then
+                num_procs=$(nproc)
+              fi
+              echo "Building with $num_procs processes..."
+
               cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-<< parameters.repo >>
-              ninja -j "$(nproc)" build-tests |& tee /logfiles/build-tests.log || ninja -j << parameters.rebuild_procs >> build-tests |& tee /logfiles/build-tests-retry.log
+              ninja -j "$num_procs" build-tests |& tee /logfiles/build-tests.log || ninja -j << parameters.rebuild_procs >> build-tests |& tee /logfiles/build-tests-retry.log

--- a/src/commands/versions.yml
+++ b/src/commands/versions.yml
@@ -10,4 +10,22 @@ steps:
   - run:
       name: "Versions, etc."
       command: |
-        mpirun --version && << parameters.compiler >> --version && echo $BASEDIR && pwd && ls && echo "$(nproc)"
+        # Determine actual number of available vCPUs
+        num_procs=""
+        if [ -f /sys/fs/cgroup/cpu.max ]; then
+          read -r quota period < /sys/fs/cgroup/cpu.max
+          if [ "$quota" != "max" ] && [ "$period" -gt 0 ]; then
+            num_procs=$(( quota / period ))
+          fi
+        elif [ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us ] && [ -f /sys/fs/cgroup/cpu/cpu.cfs_period_us ]; then
+          quota=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
+          period=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)
+          if [ "$quota" -gt 0 ] && [ "$period" -gt 0 ]; then
+            num_procs=$(( quota / period ))
+          fi
+        fi
+        if [ -z "$num_procs" ] || [ "$num_procs" -le 0 ]; then
+          num_procs=$(nproc)
+        fi
+
+        mpirun --version && << parameters.compiler >> --version && echo $BASEDIR && pwd && ls && echo "nproc: $(nproc)" && echo "Detected vCPUs: $num_procs"


### PR DESCRIPTION
This PR replaces the static nproc call with a dynamic cgroups-based (v1 and v2) calculation to accurately determine the actual allocated CPU limits on CircleCI runners.