### PR TITLE
v5: Add .GEOSdefaults.yaml, add FV3 GC to develop list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add creation of `~/.GEOSconfig.yaml` in home dir for `linkbcs.py` (see https://github.com/GEOS-ESM/GEOSgcm_App/pull/823)
+
 ## [5.31.0] - 2026-06-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Add creation of `~/.GEOSdefaults.yaml` in home dir for `linkbcs.py` (see https://github.com/GEOS-ESM/GEOSgcm_App/pull/823)
+- Add (temporarily) `FVdycoreCubed_GridComp` to the `mepo develop` list
 
 ## [5.31.0] - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.32.0] - 2026-07-10
+
 ### Changed
 
 - Add creation of `~/.GEOSdefaults.yaml` in home dir for `linkbcs.py` (see https://github.com/GEOS-ESM/GEOSgcm_App/pull/823)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add creation of `~/.GEOSconfig.yaml` in home dir for `linkbcs.py` (see https://github.com/GEOS-ESM/GEOSgcm_App/pull/823)
+- Add creation of `~/.GEOSdefaults.yaml` in home dir for `linkbcs.py` (see https://github.com/GEOS-ESM/GEOSgcm_App/pull/823)
 
 ## [5.31.0] - 2026-06-17
 

--- a/src/commands/create_gcm_expt.yml
+++ b/src/commands/create_gcm_expt.yml
@@ -38,6 +38,7 @@ steps:
       environment:
         TERM: dumb
       command: |
+        echo "boundary_dir: /TinyBCs-GitV12" >> /root/.GEOSconfig.yaml
         cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.workspace_root >>/install-<< parameters.repo >>/bin
         /TinyBCs-GitV12/scripts/create_expt.py << parameters.gcm_experiment_name >> --expdir ${CIRCLE_WORKING_DIRECTORY}/<< parameters.workspace_root >> --horz << parameters.gcm_horz_resolution >> --vert << parameters.gcm_vert_resolution >> --ocean << parameters.gcm_ocean_type >> --landbcs << parameters.landbcs_type >>
 

--- a/src/commands/create_gcm_expt.yml
+++ b/src/commands/create_gcm_expt.yml
@@ -38,7 +38,7 @@ steps:
       environment:
         TERM: dumb
       command: |
-        echo "boundary_dir: /TinyBCs-GitV12" >> /root/.GEOSconfig.yaml
+        echo "boundary_dir: /TinyBCs-GitV12" >> /root/.GEOSdefaults.yaml
         cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.workspace_root >>/install-<< parameters.repo >>/bin
         /TinyBCs-GitV12/scripts/create_expt.py << parameters.gcm_experiment_name >> --expdir ${CIRCLE_WORKING_DIRECTORY}/<< parameters.workspace_root >> --horz << parameters.gcm_horz_resolution >> --vert << parameters.gcm_vert_resolution >> --ocean << parameters.gcm_ocean_type >> --landbcs << parameters.landbcs_type >>
 

--- a/src/commands/mepodevelop.yml
+++ b/src/commands/mepodevelop.yml
@@ -8,7 +8,7 @@ parameters:
   subrepos:
     description: "Name of subrepos to run mepo develop on"
     type: string
-    default: "GEOSgcm_GridComp GEOSgcm_App GMAO_Shared"
+    default: "GEOSgcm_GridComp GEOSgcm_App GMAO_Shared GEOS_Util FVdycoreCubed_GridComp"
 
 steps:
   - run:

--- a/src/commands/mepodevelop.yml
+++ b/src/commands/mepodevelop.yml
@@ -1,4 +1,4 @@
-description: "Mepo develop GEOSgcm_GridComp GEOSgcm_App GMAO_Shared"
+description: "Mepo develop GEOSgcm_GridComp GEOSgcm_App GMAO_Shared GEOS_Util FVdycoreCubed_GridComp"
 
 parameters:
   repo:

--- a/src/commands/mepodevelop.yml
+++ b/src/commands/mepodevelop.yml
@@ -1,4 +1,4 @@
-description: "Mepo develop GEOSgcm_GridComp GEOSgcm_App GMAO_Shared GEOS_Util FVdycoreCubed_GridComp"
+description: "Mepo develop subrepos"
 
 parameters:
   repo:
@@ -8,7 +8,7 @@ parameters:
   subrepos:
     description: "Name of subrepos to run mepo develop on"
     type: string
-    default: "GEOSgcm_GridComp GEOSgcm_App GMAO_Shared GEOS_Util FVdycoreCubed_GridComp"
+    default: "GEOSgcm_GridComp GEOSgcm_App GMAO_Shared GEOS_Util"
 
 steps:
   - run:

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -78,7 +78,7 @@ parameters:
   develop_repos:
     description: "Repos to run mepo develop on"
     type: string
-    default: "GEOSgcm_GridComp GEOSgcm_App GMAO_Shared"
+    default: "GEOSgcm_GridComp GEOSgcm_App GMAO_Shared GEOS_Util FVdycoreCubed_GridComp"
   checkout_mapl_branch:
     description: "Checkout MAPL branch"
     type: boolean


### PR DESCRIPTION
This adds a `.GEOSdefaults.yaml` file for use with upcoming `linkbcs.py` work (see https://github.com/GEOS-ESM/GEOSgcm_App/pull/823)

We also add `FVdycoreCubed_GridComp` to the `mepo develop` list as (at the moment) `GEOSgcm_GridComp` depends on it