### PR TITLE
v6: Add .GEOSdefaults.yaml, add FV3 GC to develop list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,32 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [6.10.0] - 2026-06-17
+## [6.12.0] - 2026-07-10
+
+### Changed
+
+- Add creation of `~/.GEOSdefaults.yaml` in the home directory for `linkbcs.py` (see https://github.com/GEOS-ESM/GEOSgcm_App/pull/823)
+- Add `GEOS_Util` and (temporarily) `FVdycoreCubed_GridComp` to the `mepo develop` list
+
+## [6.11.0] - 2026-06-17
 
 ### Changed
 
 - Determine build CPU count dynamically using cgroups (v1/v2 CFS limit) instead of physical host CPU count (`nproc`), preventing out-of-memory and CPU-throttling issues on CircleCI runners
 
-## [6.9.0] - 2026-06-05
+## [6.10.0] - 2026-06-05
 
 ### Changed
 
 - Branch exclusion commands (`checkout_mapl_branch`, `checkout_if_exists`, `checkout_feature_branch_on_fixture_allow_fail`) now also skip feature-branch checkout logic for `release/v*` branches
 
-## [6.8.0] - 2026-06-02
+## [6.9.0] - 2026-06-02
 
 ### Changed
 
 - Updated to Baselibs 9.12.0 by default
 
-## [6.7.0] - 2026-05-13
+## [6.8.0] - 2026-05-13
 
 ### Changed
 
 - Added `run_regression_tests` to `build.yml`
 - Add `--output-on-failure` to `runtests.yml`
 
-## [6.6.0] - 2026-04-22
+## [6.7.0] - 2026-04-22
+
+Version 6.6.0 was skipped in the published release tags.
 
 ### Changed
 
@@ -733,4 +742,3 @@ So older v3 based CI will need to change their `.circleci/config.yml` to use the
 - Updated `@orb.yml`
 - Updated license to GEOS Apache
 - Updated README
-

--- a/src/commands/create_gcm_expt.yml
+++ b/src/commands/create_gcm_expt.yml
@@ -38,6 +38,6 @@ steps:
       environment:
         TERM: dumb
       command: |
+        echo "boundary_dir: /TinyBCs-GitV12" >> /root/.GEOSdefaults.yaml
         cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.workspace_root >>/install-<< parameters.repo >>/bin
         /TinyBCs-GitV12/scripts/create_expt.py << parameters.gcm_experiment_name >> --expdir ${CIRCLE_WORKING_DIRECTORY}/<< parameters.workspace_root >> --horz << parameters.gcm_horz_resolution >> --vert << parameters.gcm_vert_resolution >> --ocean << parameters.gcm_ocean_type >> --landbcs << parameters.landbcs_type >>
-

--- a/src/commands/mepodevelop.yml
+++ b/src/commands/mepodevelop.yml
@@ -1,4 +1,4 @@
-description: "Mepo develop GEOSgcm_GridComp GEOSgcm_App GMAO_Shared"
+description: "Mepo develop subrepos"
 
 parameters:
   repo:
@@ -8,7 +8,7 @@ parameters:
   subrepos:
     description: "Name of subrepos to run mepo develop on"
     type: string
-    default: "GEOSgcm_GridComp GEOSgcm_App GMAO_Shared"
+    default: "GEOSgcm_GridComp GEOSgcm_App GMAO_Shared GEOS_Util"
 
 steps:
   - run:

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -78,7 +78,7 @@ parameters:
   develop_repos:
     description: "Repos to run mepo develop on"
     type: string
-    default: "GEOSgcm_GridComp GEOSgcm_App GMAO_Shared"
+    default: "GEOSgcm_GridComp GEOSgcm_App GMAO_Shared GEOS_Util FVdycoreCubed_GridComp"
   checkout_mapl_branch:
     description: "Checkout MAPL branch"
     type: boolean


### PR DESCRIPTION
This adds a `.GEOSdefaults.yaml` file for use with upcoming `linkbcs.py` work (see https://github.com/GEOS-ESM/GEOSgcm_App/pull/823).

It also adds `GEOS_Util` and, temporarily, `FVdycoreCubed_GridComp` to the default `mepo develop` list.

The changelog is reconciled with published v6 tags and notes that `v6.6.0` was skipped.